### PR TITLE
Update count() to allow calling custom repository countBy methods with optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ https://angular.io/guide/http#intercepting-all-requests-or-responses
 + getAll()
 + get()
 + customQuery()
-+ search() in server-side with spring satify findBy* and countBy*
-+ searchSingle
++ search() on server-side with spring findBy* method in repository interface
++ searchSingle()
 + create()
 + update()
 + patch()
@@ -275,7 +275,7 @@ https://angular.io/guide/http#intercepting-all-requests-or-responses
 + prev()
 + first()
 + last()
-+ count() require implementation server-side custom repository method countAll
++ count() requires implementation of server-side custom repository method countAll, or optionally accepts a custom countBy* method name and parameters
 + totalElements()
 
 

--- a/src/resource.service.ts
+++ b/src/resource.service.ts
@@ -146,11 +146,12 @@ export class ResourceService {
             }));
     }
 
-    public count(resource: string): Observable<number> {
-        const uri = this.getResourceUrl(resource).concat('/search/countAll');
+    public count(resource: string, query? : string, options?: HalOptions): Observable<number> {
+        const uri = this.getResourceUrl(resource).concat('/search/' + (query === undefined ? 'countAll' : query));
+        const params = ResourceHelper.optionParams(new HttpParams(), options);
 
-        return ResourceHelper.getHttp().get(uri, {headers: ResourceHelper.headers, observe: 'body'}).pipe(
-            map((response: Response) => Number(response.body)),
+        return ResourceHelper.getHttp().get(uri, {headers: ResourceHelper.headers, observe: 'response', params: params}).pipe(
+            map((response: HttpResponse<number>) => Number(response.body)),
             catchError(error => observableThrowError(error)),);
     }
 

--- a/src/rest.service.ts
+++ b/src/rest.service.ts
@@ -119,8 +119,8 @@ export class RestService<T extends Resource> {
         return this.resourceService.getByRelation(this.type, relation);
     }
 
-    public count(): Observable<number> {
-        return this.resourceService.count(this.resource);
+    public count(query?: string, options?: HalOptions): Observable<number> {
+        return this.resourceService.count(this.resource, query, options);
     }
 
     public create(entity: T) {


### PR DESCRIPTION
I've come across a case where I need to call various different countBy* methods (with parameters).

I've ensured the default count() method with no parameters calls countAll on the repository as before, so this is backward compatible, but now there are two extra optional parameters to match up with the parameters available for search().

Note that this incorporates the open PR #47 but in addition changes the mapped response type to HttpResponse<number>, as that fix fails compilation for me without this.   

Please let me know if you have any suggestions for improvements or would like any changes to make this acceptable.