### PR TITLE
Check that property 'payload[result._embedded]' exists

### DIFF
--- a/src/resource-helper.ts
+++ b/src/resource-helper.ts
@@ -112,15 +112,17 @@ export class ResourceHelper {
 
     static instantiateResourceCollection<T extends Resource>(type: { new(): T }, payload: any,
                                                              result: ResourceArray<T>, builder?: SubTypeBuilder): ResourceArray<T> {
-        for (const embeddedClassName of Object.keys(payload[result._embedded])) {
-            let embedded: any = payload[result._embedded];
-            const items = embedded[embeddedClassName];
-            for (let item of items) {
-                let instance: T = new type();
-                instance = this.searchSubtypes(builder, embeddedClassName, instance);
+        if (payload[result._embedded]) {
+            for (const embeddedClassName of Object.keys(payload[result._embedded])) {
+                let embedded: any = payload[result._embedded];
+                const items = embedded[embeddedClassName];
+                for (let item of items) {
+                    let instance: T = new type();
+                    instance = this.searchSubtypes(builder, embeddedClassName, instance);
 
-                this.instantiateResource(instance, item);
-                result.push(instance);
+                    this.instantiateResource(instance, item);
+                    result.push(instance);
+                }
             }
         }
 


### PR DESCRIPTION
It drops js error when it's not presented:

![image](https://user-images.githubusercontent.com/9264502/52489378-66cef600-2bc2-11e9-963e-85b2db711db3.png)