### PR TITLE
 Change Observable imports

### DIFF
--- a/src/array-interface.ts
+++ b/src/array-interface.ts
@@ -1,7 +1,7 @@
 import {Sort} from './sort';
 import {ResourceArray} from './resource-array';
 import {Resource} from './resource';
-import {Observable} from 'rxjs/internal/Observable';
+import {Observable} from 'rxjs';
 
 export interface ArrayInterface<T extends Resource> {
     totalElements: number;

--- a/src/resource.service.ts
+++ b/src/resource.service.ts
@@ -1,4 +1,4 @@
-import {throwError as observableThrowError} from 'rxjs';
+import {throwError as observableThrowError, Observable} from 'rxjs';
 
 import {catchError, map} from 'rxjs/operators';
 import {Resource} from './resource';
@@ -10,7 +10,6 @@ import {ResourceArray} from './resource-array';
 import {ExternalService} from './external.service';
 import {HalOptions, HalParam} from './rest.service';
 import {SubTypeBuilder} from './subtype-builder';
-import {Observable} from 'rxjs/internal/Observable';
 import {CustomEncoder} from './CustomEncoder';
 
 @Injectable()

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -1,4 +1,4 @@
-import {of as observableOf, throwError as observableThrowError} from 'rxjs';
+import {of as observableOf, throwError as observableThrowError, Observable} from 'rxjs';
 
 import {catchError, map} from 'rxjs/operators';
 import {HttpParams} from '@angular/common/http';
@@ -10,7 +10,6 @@ import {SubTypeBuilder} from './subtype-builder';
 import {Injectable} from '@angular/core';
 import {CustomEncoder} from './CustomEncoder';
 import {Utils} from './Utils';
-import {Observable} from 'rxjs/internal/Observable';
 import {CacheHelper} from './cache/cache.helper';
 
 export type Link = { href: string, templated?: boolean };

--- a/src/rest.service.ts
+++ b/src/rest.service.ts
@@ -1,11 +1,10 @@
-import {of as observableOf, throwError as observableThrowError} from 'rxjs';
+import {of as observableOf, throwError as observableThrowError, Observable} from 'rxjs';
 import {map, mergeMap} from 'rxjs/operators';
 import {Resource} from './resource';
 import {ResourceArray} from './resource-array';
 import {Sort} from './sort';
 import {ResourceService} from './resource.service';
 import {SubTypeBuilder} from './subtype-builder';
-import {Observable} from 'rxjs/internal/Observable';
 import {Injector} from '@angular/core';
 import {Utils} from './Utils';
 


### PR DESCRIPTION
I changed the import of Observable from "import { Observable } from 'rxjs/internal/Observable';" to "import { Observable } from 'rxjs';" to improve the usability.