### PR TITLE
Pagination Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HAL Library Angular 4 to 7
+# HAL Library Angular 4 to 8
 
 This Angular module offers a [HAL/JSON](http://stateless.co/hal_specification.html) http-client to easily interact with a [Spring Data Rest](https://projects.spring.io/spring-data-rest) API (and by extend any API that conforms the Spring Data Rest resource model)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HAL Library Angular 4 to 8
+# HAL Library Angular 4 to 7
 
 This Angular module offers a [HAL/JSON](http://stateless.co/hal_specification.html) http-client to easily interact with a [Spring Data Rest](https://projects.spring.io/spring-data-rest) API (and by extend any API that conforms the Spring Data Rest resource model)
 

--- a/src/resource-array.ts
+++ b/src/resource-array.ts
@@ -87,8 +87,7 @@ export class ResourceArray<T extends Resource> implements ArrayInterface<T> {
 // Load page with given pageNumber
 
     page = (type: { new(): T }, pageNumber: number): Observable<ResourceArray<T>> => {
-        this.self_uri = this.self_uri.replace('{?page,size,sort,projection}', '');
-        this.self_uri = this.self_uri.replace('{&sort}', '');
+        this.self_uri = this.self_uri.replace(/({.+})/i, '');
         let urlParsed = url.parse(ResourceHelper.getProxy(this.self_uri));
         let query: string = ResourceArray.replaceOrAdd(urlParsed.query, 'size', this.pageSize.toString());
         query = ResourceArray.replaceOrAdd(query, 'page', pageNumber.toString());
@@ -106,8 +105,7 @@ export class ResourceArray<T extends Resource> implements ArrayInterface<T> {
 
 
     sortElements = (type: { new(): T }, ...sort: Sort[]): Observable<ResourceArray<T>> => {
-        this.self_uri = this.self_uri.replace('{?page,size,sort}', '');
-        this.self_uri = this.self_uri.replace('{&sort}', '');
+      this.self_uri = this.self_uri.replace(/({.+})/i, '');
         let uri = ResourceHelper.getProxy(this.self_uri).concat('?', 'size=', this.pageSize.toString(), '&page=', this.pageNumber.toString());
         uri = this.addSortInfo(uri);
         return ResourceHelper.getHttp().get(uri, {headers: ResourceHelper.headers, observe: 'response'}).pipe(
@@ -140,7 +138,7 @@ export class ResourceArray<T extends Resource> implements ArrayInterface<T> {
             let idxNextAmp: number = query.indexOf('&', idx) == -1 ? query.indexOf('/', idx) : query.indexOf('&', idx);
 
             if (idx != -1) {
-                let seachValue = query.substring(idx, idxNextAmp);
+                let seachValue = query.substring(idx, (idxNextAmp == -1 ? query.length : idxNextAmp));
                 query = query.replace(seachValue, field + '=' + value);
             } else {
                 query = query.concat("&" + field + '=' + value);

--- a/src/resource-helper.ts
+++ b/src/resource-helper.ts
@@ -199,7 +199,7 @@ export class ResourceHelper {
     }
 
     public static getProxy(url: string): string {
-        url = url.replace('{?projection}', '');
+        url = url.replace(/({.+})/i, '');
         if (!ResourceHelper.proxy_uri || ResourceHelper.proxy_uri == '')
             return url;
         return ResourceHelper.addSlash(url.replace(ResourceHelper.root_uri, ResourceHelper.proxy_uri));

--- a/src/resource.service.ts
+++ b/src/resource.service.ts
@@ -276,7 +276,7 @@ export class ResourceService {
             return url.concat(resource);
         }
 
-        url = url.replace('{?projection}', '');
+        url = url.replace(/({.+})/i, '');
         return url;
     }
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -153,13 +153,13 @@ export abstract class Resource {
             return url.concat(resource);
         }
 
-        url = url.replace('{?projection}', '');
+        url = url.replace(/({.+})/i, '');
         return url;
     }
 
     private getRelationLinkHref(relation: string) {
         if (this._links[relation].templated)
-            return this._links[relation].href.replace('{?projection}', '');
+            return this._links[relation].href.replace(/({.+})/i, '');
         return this._links[relation].href;
     }
 


### PR DESCRIPTION
The replaces of self_uri were using static strings.
If the endpoints has no projections or when the sel_uri is a search result, the replace fail and generate a invalid uri.
To fix that I changed the replaces to use regex.

I also fix the uri parameters replace to properly work when the target parameter is the last parameter on the uri.

Examples of uris:         this.self_uri = this.self_uri.replace('{?page,size,sort,projection}', '');
"https://localhost:8080/entity{?page,size,sort}"
"https://localhost:8080/entity/search/findByName{?name}"